### PR TITLE
Fix #21

### DIFF
--- a/src/PlantUmlTextEncoding.cs
+++ b/src/PlantUmlTextEncoding.cs
@@ -12,7 +12,7 @@ namespace PlantUml.Net
     {
         public static string EncodeUrl(string text)
         {
-            return Encode64(Deflate(Encoding.UTF8.GetString(Encoding.Default.GetBytes(text))));
+            return Encode64(Deflate(text));
         }
 
         private static byte[] Deflate(string text)


### PR DESCRIPTION
This fixes #21 for me but i'm not sure if it breaks some other things. To be honest i'd expect that the line `Encoding.UTF8.GetString(Encoding.Default.GetBytes(text)))` has some special meaning?