### PR TITLE
Add Encoding.Convert to avoid GBK to UTF8 issue

### DIFF
--- a/src/PlantUmlTextEncoding.cs
+++ b/src/PlantUmlTextEncoding.cs
@@ -12,7 +12,7 @@ namespace PlantUml.Net
     {
         public static string EncodeUrl(string text)
         {
-            return Encode64(Deflate(Encoding.UTF8.GetString(Encoding.Default.GetBytes(text))));
+            return Encode64(Deflate(Encoding.UTF8.GetString(Encoding.Convert(Encoding.Default, Encoding.UTF8, Encoding.Default.GetBytes(text)))));
         }
 
         private static byte[] Deflate(string text)


### PR DESCRIPTION
Hi

When I tried below code， PlantUml.net not work as expected. 

```
var bytes = renderer.Render(":租户公司已创建;", OutputFormat.Svg);
string svg = Encoding.UTF8.GetString(bytes);
```
The text string will be send to Plant server in below image

![image](https://user-images.githubusercontent.com/2484031/143573792-c00c71c5-6d13-437d-b929-720ec15a29f9.png)


The reason is the method "EncodeUrl" in "PlantUmlTextEncoding" was not convert input string to UTF-8 correctly when it contains Chinese characters.  To avoid this issue, we have to add an Encoding.Convert after GetByts.

Please review and test this issue.

Thanks