### PR TITLE
Fixed stream writer needs to be used without BOM

### DIFF
--- a/src/Java/JarRunner.cs
+++ b/src/Java/JarRunner.cs
@@ -12,6 +12,11 @@ namespace PlantUml.Net.Java
 
         public JarRunner(string javaPath, string jarPath)
         {
+            if (!File.Exists(javaPath))
+            {
+                throw new JavaNotFoundException($"Java executable '{javaPath}' does not exist");
+            }
+
             this.javaPath = javaPath;
             this.jarPath = jarPath;
         }

--- a/src/Java/JarRunner.cs
+++ b/src/Java/JarRunner.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 using PlantUml.Net.Tools;

--- a/src/Java/JarRunner.cs
+++ b/src/Java/JarRunner.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 using PlantUml.Net.Tools;

--- a/src/Local/LocalPlantUmlRenderer.cs
+++ b/src/Local/LocalPlantUmlRenderer.cs
@@ -23,7 +23,7 @@ namespace PlantUml.Net.Local
         public async Task<byte[]> RenderAsync(string code, OutputFormat outputFormat, CancellationToken cancellationToken = default)
         {
             string command = commandProvider.GetCommand(outputFormat);
-            var processResult = await jarRunner.RunJarWithInputAsync(code, cancellationToken, command, "-pipe")
+            var processResult = await jarRunner.RunJarWithInputAsync(code, cancellationToken, command, "-pipe", "-charset UTF-8")
                 .ConfigureAwait(false);
             if (processResult.ExitCode != 0)
             {

--- a/src/Tools/ProcessExtensions.cs
+++ b/src/Tools/ProcessExtensions.cs
@@ -8,7 +8,7 @@ namespace PlantUml.Net.Tools
     {
         public static void WriteInput(this Process process, string input)
         {
-            using (StreamWriter stdIn = new StreamWriter(process.StandardInput.BaseStream, Encoding.UTF8))
+            using (StreamWriter stdIn = new StreamWriter(process.StandardInput.BaseStream, new UTF8Encoding(false)))
             {
                 stdIn.AutoFlush = true;
                 stdIn.Write(input);


### PR DESCRIPTION
Streams passed to PlantUML should not include the BOM. Minimal sample which shows this:

Does not work with the current implementation (only the second diagram is generated):

```
@startuml
Bob1 -> Alice1
@enduml
@startuml
Bob2 -> Alice2
@enduml
```


Works (both diagrams are generated due to a leading new line):
```

@startuml
Bob1 -> Alice1
@enduml
@startuml
Bob2 -> Alice2
@enduml
```

Setting the encoding like done in the commit fixes the issue.